### PR TITLE
Enabling clamping for the scales

### DIFF
--- a/Sources/SwiftViz/DateTick.swift
+++ b/Sources/SwiftViz/DateTick.swift
@@ -8,7 +8,6 @@
 import CoreGraphics
 import Foundation
 
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, *)
 public struct DateTick: Tick {
     public let id = UUID()
     // making this identifiable as a convenience
@@ -17,11 +16,6 @@ public struct DateTick: Tick {
 
     public let value: Date
     public let rangeLocation: CGFloat // location maps to the output range of the Scale
-
-    private let fm = ISO8601DateFormatter()
-    public var stringValue: String {
-        fm.string(from: value)
-    }
 
     // public initializer needed in a library, the auto-generated one isn't auto-public
     public init(value: Date, location: CGFloat) {

--- a/Sources/SwiftViz/LinearScale.swift
+++ b/Sources/SwiftViz/LinearScale.swift
@@ -26,14 +26,14 @@ public struct LinearScale: Scale {
     public func scale(_ inputValue: CGFloat, range: ClosedRange<CGFloat>) -> CGFloat {
         let result = interpolate(normalize(inputValue, domain: domain), range: range)
         // if we're clamped, constrain the output to the range
-        return self.clamp(result, withinRange: range)
+        return self.clampRange(result, withinRange: range)
     }
 
     /// inverts the scale, taking a value in the output range and returning the relevant value from the input domain
     public func invert(_ outputValue: CGFloat, range: ClosedRange<CGFloat>) -> CGFloat {
         let result = interpolate(normalize(outputValue, domain: range), range: domain)
         // if we're clamped, constrain the output to the domain
-        return self.clamp(result, withinRange: range)
+        return self.clampDomain(result, withinRange: self.domain)
     }
 
     /// returns an array of the locations of ticks - (value, location)

--- a/Sources/SwiftViz/LinearScale.swift
+++ b/Sources/SwiftViz/LinearScale.swift
@@ -26,14 +26,14 @@ public struct LinearScale: Scale {
     public func scale(_ inputValue: CGFloat, range: ClosedRange<CGFloat>) -> CGFloat {
         let result = interpolate(normalize(inputValue, domain: domain), range: range)
         // if we're clamped, constrain the output to the range
-        return self.clampRange(result, withinRange: range)
+        return clampRange(result, withinRange: range)
     }
 
     /// inverts the scale, taking a value in the output range and returning the relevant value from the input domain
     public func invert(_ outputValue: CGFloat, range: ClosedRange<CGFloat>) -> CGFloat {
         let result = interpolate(normalize(outputValue, domain: range), range: domain)
         // if we're clamped, constrain the output to the domain
-        return self.clampDomain(result, withinRange: self.domain)
+        return clampDomain(result, withinRange: domain)
     }
 
     /// returns an array of the locations of ticks - (value, location)

--- a/Sources/SwiftViz/LinearScale.swift
+++ b/Sources/SwiftViz/LinearScale.swift
@@ -24,12 +24,16 @@ public struct LinearScale: Scale {
     /// - Parameter x: value within the domain
     /// - Returns: scaled value
     public func scale(_ inputValue: CGFloat, range: ClosedRange<CGFloat>) -> CGFloat {
-        interpolate(normalize(inputValue, domain: domain), range: range)
+        let result = interpolate(normalize(inputValue, domain: domain), range: range)
+        // if we're clamped, constrain the output to the range
+        return self.clamp(result, withinRange: range)
     }
 
     /// inverts the scale, taking a value in the output range and returning the relevant value from the input domain
     public func invert(_ outputValue: CGFloat, range: ClosedRange<CGFloat>) -> CGFloat {
-        interpolate(normalize(outputValue, domain: range), range: domain)
+        let result = interpolate(normalize(outputValue, domain: range), range: domain)
+        // if we're clamped, constrain the output to the domain
+        return self.clamp(result, withinRange: range)
     }
 
     /// returns an array of the locations of ticks - (value, location)

--- a/Sources/SwiftViz/LogScale.swift
+++ b/Sources/SwiftViz/LogScale.swift
@@ -32,7 +32,7 @@ public struct LogScale: Scale {
         let logDomain = log10(domain.lowerBound) ... log10(domain.upperBound)
         let normalizedValueOnLogDomain = normalize(logResult, domain: logDomain)
         let valueMappedToRange = interpolate(normalizedValueOnLogDomain, range: range)
-        return self.clampRange(valueMappedToRange, withinRange: range)
+        return clampRange(valueMappedToRange, withinRange: range)
     }
 
     /// inverts the scale, taking a value in the output range and returning the relevant value from the input domain
@@ -40,7 +40,7 @@ public struct LogScale: Scale {
         let normalizedRangeValue = normalize(rangeValue, domain: range)
         let logDomain = log10(domain.lowerBound) ... log10(domain.upperBound)
         let linear = interpolate(normalizedRangeValue, range: logDomain)
-        return self.clampDomain(pow(10, linear), withinRange: self.domain)
+        return clampDomain(pow(10, linear), withinRange: domain)
     }
 
     /// returns an array of the locations of ticks - (value, location)

--- a/Sources/SwiftViz/LogScale.swift
+++ b/Sources/SwiftViz/LogScale.swift
@@ -32,7 +32,7 @@ public struct LogScale: Scale {
         let logDomain = log10(domain.lowerBound) ... log10(domain.upperBound)
         let normalizedValueOnLogDomain = normalize(logResult, domain: logDomain)
         let valueMappedToRange = interpolate(normalizedValueOnLogDomain, range: range)
-        return valueMappedToRange
+        return self.clampRange(valueMappedToRange, withinRange: range)
     }
 
     /// inverts the scale, taking a value in the output range and returning the relevant value from the input domain
@@ -40,7 +40,7 @@ public struct LogScale: Scale {
         let normalizedRangeValue = normalize(rangeValue, domain: range)
         let logDomain = log10(domain.lowerBound) ... log10(domain.upperBound)
         let linear = interpolate(normalizedRangeValue, range: logDomain)
-        return pow(10, linear)
+        return self.clampDomain(pow(10, linear), withinRange: self.domain)
     }
 
     /// returns an array of the locations of ticks - (value, location)

--- a/Sources/SwiftViz/Scale.swift
+++ b/Sources/SwiftViz/Scale.swift
@@ -25,8 +25,23 @@ public protocol Scale {
     // this becomes a generic focused protocol - types implementing it will need to define the
     // protocol conformance in coordination with a generic type
 
-    // clamped constrains the output mapping through the input domain to the output range so that it's always
-    // inside the outputRange
+    /*
+     tape("linear.clamp(true) restricts output values to the range", function(test) {
+       test.equal(d3.scale.linear().clamp(true).range([10, 20])(2), 20);
+       test.equal(d3.scale.linear().clamp(true).range([10, 20])(-1), 10);
+       test.end();
+     });
+
+     tape("linear.clamp(true) restricts input values to the domain", function(test) {
+       test.equal(d3.scale.linear().clamp(true).range([10, 20]).invert(30), 1);
+       test.equal(d3.scale.linear().clamp(true).range([10, 20]).invert(0), 0);
+       test.end();
+     });
+     */
+
+    // clamped forces constraints on both the domain and the range. Any scaled values
+    // will be constrained the output range, and any inverted values will be constrained
+    // to the input domain.
     var isClamped: Bool { get }
 
     // input values
@@ -65,6 +80,21 @@ public protocol Scale {
     ///   the range we are mapping the values into with the scale
     /// - Returns: an Array of the values within the ClosedRange of range
     func ticks(count: Int, range: ClosedRange<CGFloat>) -> [TickType]
+}
+
+extension Scale {
+    // returns the a constrained value to the provided IF isClamped is true
+    public func clamp(_ value: InputType, withinRange: ClosedRange<InputType>) -> InputType {
+        if (self.isClamped) {
+            if (value > withinRange.upperBound) {
+                return withinRange.upperBound
+            }
+            if (value < withinRange.lowerBound) {
+                return withinRange.lowerBound
+            }
+        }
+        return value
+    }
 }
 
 extension Scale where InputType == TickType.InputType {

--- a/Sources/SwiftViz/Scale.swift
+++ b/Sources/SwiftViz/Scale.swift
@@ -84,11 +84,11 @@ public protocol Scale {
 
 extension ClosedRange {
     public func constrainedToRange(_ value: Bound) -> Bound {
-        if (value > self.upperBound) {
-            return self.upperBound
+        if value > upperBound {
+            return upperBound
         }
-        if (value < self.lowerBound) {
-            return self.lowerBound
+        if value < lowerBound {
+            return lowerBound
         }
         return value
     }
@@ -97,14 +97,14 @@ extension ClosedRange {
 extension Scale {
     // returns the a constrained value to the provided IF isClamped is true
     public func clampDomain(_ value: InputType, withinRange: ClosedRange<InputType>) -> InputType {
-        if (self.isClamped) {
+        if isClamped {
             return withinRange.constrainedToRange(value)
         }
         return value
     }
-    
+
     public func clampRange(_ value: CGFloat, withinRange: ClosedRange<CGFloat>) -> CGFloat {
-        if (self.isClamped) {
+        if isClamped {
             return withinRange.constrainedToRange(value)
         }
         return value
@@ -190,8 +190,8 @@ extension Scale where InputType == TickType.InputType {
 /// It returns the corresponding parameter within the range [0...1] if it was within the domain of the scale
 /// If the value provided is outside of the domain of the scale, the resulting normalized value will be extrapolated
 func normalize(_ x: CGFloat, domain: ClosedRange<CGFloat>) -> CGFloat {
-        let rangeDistance = domain.upperBound - domain.lowerBound
-        return (x - domain.lowerBound) / rangeDistance
+    let rangeDistance = domain.upperBound - domain.lowerBound
+    return (x - domain.lowerBound) / rangeDistance
 }
 
 // inspiration - https://github.com/d3/d3-interpolate#interpolateNumber

--- a/Sources/SwiftViz/TimeScale.swift
+++ b/Sources/SwiftViz/TimeScale.swift
@@ -42,7 +42,7 @@ public struct TimeScale: Scale {
         let inputAsFloat = CGFloat(inputValue.timeIntervalSince1970)
         let dateDomainAsFloat = CGFloat(domain.lowerBound.timeIntervalSince1970) ... CGFloat(domain.upperBound.timeIntervalSince1970)
         let valueMappedToRange = interpolate(normalize(inputAsFloat, domain: dateDomainAsFloat), range: range)
-        return self.clampRange(valueMappedToRange, withinRange: range)
+        return clampRange(valueMappedToRange, withinRange: range)
     }
 
     /// converts back from the output "range" to a value within
@@ -56,7 +56,7 @@ public struct TimeScale: Scale {
         let normalizedFloatFromRange = normalize(outputValue, domain: range)
         let interpolatedInterval = CGFloat(domain.lowerBound.timeIntervalSince1970) * (1 - normalizedFloatFromRange) + CGFloat(domain.upperBound.timeIntervalSince1970) * normalizedFloatFromRange
         let attemptedDate = Date(timeIntervalSince1970: TimeInterval(interpolatedInterval))
-        return self.clampDomain(attemptedDate, withinRange: self.domain)
+        return clampDomain(attemptedDate, withinRange: domain)
     }
 
     func interpolateDate(_ x: CGFloat, range: ClosedRange<Date>) -> Date {

--- a/Sources/SwiftViz/TimeScale.swift
+++ b/Sources/SwiftViz/TimeScale.swift
@@ -22,7 +22,6 @@ import Foundation
 // - D3 has a time format (https://github.com/d3/d3-time-format), but we can probably use
 //   IOS/MacOS NSTime, NSDate formatters and calendrical mechanisms
 
-@available(OSX 10.12, watchOS 3.0, *)
 public struct TimeScale: Scale {
     public typealias InputType = Date
     public typealias TickType = DateTick
@@ -43,7 +42,7 @@ public struct TimeScale: Scale {
         let inputAsFloat = CGFloat(inputValue.timeIntervalSince1970)
         let dateDomainAsFloat = CGFloat(domain.lowerBound.timeIntervalSince1970) ... CGFloat(domain.upperBound.timeIntervalSince1970)
         let valueMappedToRange = interpolate(normalize(inputAsFloat, domain: dateDomainAsFloat), range: range)
-        return valueMappedToRange
+        return self.clampRange(valueMappedToRange, withinRange: range)
     }
 
     /// converts back from the output "range" to a value within
@@ -57,10 +56,7 @@ public struct TimeScale: Scale {
         let normalizedFloatFromRange = normalize(outputValue, domain: range)
         let interpolatedInterval = CGFloat(domain.lowerBound.timeIntervalSince1970) * (1 - normalizedFloatFromRange) + CGFloat(domain.upperBound.timeIntervalSince1970) * normalizedFloatFromRange
         let attemptedDate = Date(timeIntervalSince1970: TimeInterval(interpolatedInterval))
-        //        if domain.contains(attemptedDate) {
-        //            return attemptedDate
-        //        }
-        return attemptedDate
+        return self.clampDomain(attemptedDate, withinRange: self.domain)
     }
 
     func interpolateDate(_ x: CGFloat, range: ClosedRange<Date>) -> Date {

--- a/Tests/SwiftVizTests/ExternalPackageTests.swift
+++ b/Tests/SwiftVizTests/ExternalPackageTests.swift
@@ -52,13 +52,13 @@ final class PackagingTests: XCTestCase {
     func testScaleClamp() {
         let scale = LinearScale(domain: 5 ... 10.0)
         // default isClamped is false - no clamping
-        XCTAssertEqual(scale.clamp(11.0, withinRange: 5 ... 10.0), 11.0)
-        XCTAssertEqual(scale.clamp(1.0, withinRange: 5 ... 10.0), 1.0)
-        XCTAssertEqual(scale.clamp(7.0, withinRange: 5 ... 10.0), 7.0)
+        XCTAssertEqual(scale.clampRange(11.0, withinRange: 5 ... 10.0), 11.0)
+        XCTAssertEqual(scale.clampRange(1.0, withinRange: 5 ... 10.0), 1.0)
+        XCTAssertEqual(scale.clampRange(7.0, withinRange: 5 ... 10.0), 7.0)
 
         let cScale = LinearScale(domain: 5 ... 10.0, isClamped: true)
-        XCTAssertEqual(cScale.clamp(11.0, withinRange: 5 ... 10.0), 10.0)
-        XCTAssertEqual(cScale.clamp(1.0, withinRange: 5 ... 10.0), 5.0)
-        XCTAssertEqual(scale.clamp(7.0, withinRange: 5 ... 10.0), 7.0)
+        XCTAssertEqual(cScale.clampDomain(11.0, withinRange: 5 ... 10.0), 10.0)
+        XCTAssertEqual(cScale.clampDomain(1.0, withinRange: 5 ... 10.0), 5.0)
+        XCTAssertEqual(scale.clampDomain(7.0, withinRange: 5 ... 10.0), 7.0)
     }
 }

--- a/Tests/SwiftVizTests/ExternalPackageTests.swift
+++ b/Tests/SwiftVizTests/ExternalPackageTests.swift
@@ -48,4 +48,17 @@ final class PackagingTests: XCTestCase {
         XCTAssertEqual(validatedSet[0].value, "1")
         XCTAssertEqual(validatedSet[1].value, "10")
     }
+
+    func testScaleClamp() {
+        let scale = LinearScale(domain: 5 ... 10.0)
+        // default isClamped is false - no clamping
+        XCTAssertEqual(scale.clamp(11.0, withinRange: 5 ... 10.0), 11.0)
+        XCTAssertEqual(scale.clamp(1.0, withinRange: 5 ... 10.0), 1.0)
+        XCTAssertEqual(scale.clamp(7.0, withinRange: 5 ... 10.0), 7.0)
+
+        let cScale = LinearScale(domain: 5 ... 10.0, isClamped: true)
+        XCTAssertEqual(cScale.clamp(11.0, withinRange: 5 ... 10.0), 10.0)
+        XCTAssertEqual(cScale.clamp(1.0, withinRange: 5 ... 10.0), 5.0)
+        XCTAssertEqual(scale.clamp(7.0, withinRange: 5 ... 10.0), 7.0)
+    }
 }

--- a/Tests/SwiftVizTests/LinearScaleTests.swift
+++ b/Tests/SwiftVizTests/LinearScaleTests.swift
@@ -35,25 +35,6 @@ final class LinearScaleTests: XCTestCase {
         }
     }
 
-    @available(OSX 10.12, *)
-    func testTimeScale() {
-        let start = Date() - TimeInterval(300)
-        let end = Date()
-        let myTimeScale = TimeScale(domain: start ... end, isClamped: false)
-
-        let testRange = CGFloat(0) ... CGFloat(100.0)
-
-        // print("range is \(myTimeScale.domain)")
-        let defaultTicks = myTimeScale.ticks(range: testRange)
-        XCTAssertEqual(defaultTicks.count, 11)
-        for tick in defaultTicks {
-            // every tick should be from within the scale's domain (input) range
-            XCTAssertTrue(testRange.contains(tick.rangeLocation))
-            // XCTAssert(myTimeScale.domain.contains(tick.value))
-            // print("tick \(tick.value) at location \(tick.rangeLocation)")
-        }
-    }
-
     func testLinearScaleClamp() {
         let scale = LinearScale(domain: 0 ... 10.0)
         let clampedScale = LinearScale(domain: 0 ... 10.0, isClamped: true)
@@ -66,8 +47,8 @@ final class LinearScaleTests: XCTestCase {
         XCTAssertEqual(clampedScale.scale(5, range: testRange), 50)
 
         // clamp constrained high
-        XCTAssertEqual(scale.scale(11, range: testRange), 110)
-        XCTAssertEqual(clampedScale.scale(11, range: testRange), 100)
+        XCTAssertEqual(scale.scale(11, range: testRange), 110, accuracy: 0.001)
+        XCTAssertEqual(clampedScale.scale(11, range: testRange), 100, accuracy: 0.001)
 
         // clamp constrained low
         XCTAssertEqual(scale.scale(-1, range: testRange), -10)
@@ -75,9 +56,23 @@ final class LinearScaleTests: XCTestCase {
     }
 
     func testLinearInvertClamp() {
-        let myScale = LinearScale(domain: 0 ... 10.0, isClamped: true)
-        XCTAssertTrue(myScale.isClamped)
+        let scale = LinearScale(domain: 0 ... 10.0)
+        let clampedScale = LinearScale(domain: 0 ... 10.0, isClamped: true)
+        XCTAssertFalse(scale.isClamped)
+        XCTAssertTrue(clampedScale.isClamped)
         let testRange = CGFloat(0) ... CGFloat(100.0)
+
+        // no clamp effect
+        XCTAssertEqual(scale.invert(50, range: testRange), 5)
+        XCTAssertEqual(clampedScale.invert(50, range: testRange), 5)
+
+        // clamp constrained high
+        XCTAssertEqual(scale.invert(110, range: testRange), 11, accuracy: 0.001)
+        XCTAssertEqual(clampedScale.invert(110, range: testRange), 10, accuracy: 0.001)
+
+        // clamp constrained low
+        XCTAssertEqual(scale.invert(-10, range: testRange), -1)
+        XCTAssertEqual(clampedScale.invert(-10, range: testRange), 0)
 
     }
 }

--- a/Tests/SwiftVizTests/LinearScaleTests.swift
+++ b/Tests/SwiftVizTests/LinearScaleTests.swift
@@ -73,6 +73,5 @@ final class LinearScaleTests: XCTestCase {
         // clamp constrained low
         XCTAssertEqual(scale.invert(-10, range: testRange), -1)
         XCTAssertEqual(clampedScale.invert(-10, range: testRange), 0)
-
     }
 }

--- a/Tests/SwiftVizTests/LinearScaleTests.swift
+++ b/Tests/SwiftVizTests/LinearScaleTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class LinearScaleTests: XCTestCase {
     func testLinearScaleTicks() {
-        let myScale = LinearScale(domain: 0 ... 1.0, isClamped: false)
+        let myScale = LinearScale(domain: 0 ... 1.0)
         XCTAssertFalse(myScale.isClamped)
 
         let testRange = CGFloat(0) ... CGFloat(100.0)
@@ -21,7 +21,7 @@ final class LinearScaleTests: XCTestCase {
     }
 
     func testLinearScaleManualTicks() {
-        let myScale = LinearScale(domain: 0 ... 1.0, isClamped: false)
+        let myScale = LinearScale(domain: 0 ... 1.0)
         XCTAssertFalse(myScale.isClamped)
 
         let testRange = CGFloat(0) ... CGFloat(100.0)
@@ -52,5 +52,32 @@ final class LinearScaleTests: XCTestCase {
             // XCTAssert(myTimeScale.domain.contains(tick.value))
             // print("tick \(tick.value) at location \(tick.rangeLocation)")
         }
+    }
+
+    func testLinearScaleClamp() {
+        let scale = LinearScale(domain: 0 ... 10.0)
+        let clampedScale = LinearScale(domain: 0 ... 10.0, isClamped: true)
+        XCTAssertFalse(scale.isClamped)
+        XCTAssertTrue(clampedScale.isClamped)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+
+        // no clamp effect
+        XCTAssertEqual(scale.scale(5, range: testRange), 50)
+        XCTAssertEqual(clampedScale.scale(5, range: testRange), 50)
+
+        // clamp constrained high
+        XCTAssertEqual(scale.scale(11, range: testRange), 110)
+        XCTAssertEqual(clampedScale.scale(11, range: testRange), 100)
+
+        // clamp constrained low
+        XCTAssertEqual(scale.scale(-1, range: testRange), -10)
+        XCTAssertEqual(clampedScale.scale(-1, range: testRange), 0)
+    }
+
+    func testLinearInvertClamp() {
+        let myScale = LinearScale(domain: 0 ... 10.0, isClamped: true)
+        XCTAssertTrue(myScale.isClamped)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+
     }
 }

--- a/Tests/SwiftVizTests/LogScaleTests.swift
+++ b/Tests/SwiftVizTests/LogScaleTests.swift
@@ -97,4 +97,47 @@ class LogScaleTests: XCTestCase {
             XCTAssert(myScale.domain.contains(tick.value))
         }
     }
+
+    func testLogScaleClamp() {
+        let scale = LogScale(domain: 1 ... 100.0)
+        let clampedScale = LogScale(domain: 1 ... 100.0, isClamped: true)
+        
+        XCTAssertFalse(scale.isClamped)
+        XCTAssertTrue(clampedScale.isClamped)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+
+        // no clamp effect
+        XCTAssertEqual(scale.scale(10, range: testRange), 50)
+        XCTAssertEqual(clampedScale.scale(10, range: testRange), 50)
+
+        // clamp constrained high
+        XCTAssertEqual(scale.scale(1000, range: testRange), 150, accuracy: 0.001)
+        XCTAssertEqual(clampedScale.scale(1000, range: testRange), 100, accuracy: 0.001)
+
+        // clamp constrained low
+        XCTAssertEqual(scale.scale(0.1, range: testRange), -50)
+        XCTAssertEqual(clampedScale.scale(0.1, range: testRange), 0)
+    }
+
+    func testLogInvertClamp() {
+        let scale = LogScale(domain: 1 ... 100.0)
+        let clampedScale = LogScale(domain: 1 ... 100.0, isClamped: true)
+
+        XCTAssertFalse(scale.isClamped)
+        XCTAssertTrue(clampedScale.isClamped)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+
+
+        // no clamp effect
+        XCTAssertEqual(scale.invert(50, range: testRange), 10)
+        XCTAssertEqual(clampedScale.invert(50, range: testRange), 10)
+
+        // clamp constrained high
+        XCTAssertEqual(scale.invert(150, range: testRange), 1000, accuracy: 0.001)
+        XCTAssertEqual(clampedScale.invert(150, range: testRange), 100, accuracy: 0.001)
+
+        // clamp constrained low
+        XCTAssertEqual(scale.invert(-50, range: testRange), 0.1)
+        XCTAssertEqual(clampedScale.invert(-50, range: testRange), 1.0)
+    }
 }

--- a/Tests/SwiftVizTests/LogScaleTests.swift
+++ b/Tests/SwiftVizTests/LogScaleTests.swift
@@ -101,7 +101,7 @@ class LogScaleTests: XCTestCase {
     func testLogScaleClamp() {
         let scale = LogScale(domain: 1 ... 100.0)
         let clampedScale = LogScale(domain: 1 ... 100.0, isClamped: true)
-        
+
         XCTAssertFalse(scale.isClamped)
         XCTAssertTrue(clampedScale.isClamped)
         let testRange = CGFloat(0) ... CGFloat(100.0)
@@ -126,7 +126,6 @@ class LogScaleTests: XCTestCase {
         XCTAssertFalse(scale.isClamped)
         XCTAssertTrue(clampedScale.isClamped)
         let testRange = CGFloat(0) ... CGFloat(100.0)
-
 
         // no clamp effect
         XCTAssertEqual(scale.invert(50, range: testRange), 10)

--- a/Tests/SwiftVizTests/NormalizeTests.swift
+++ b/Tests/SwiftVizTests/NormalizeTests.swift
@@ -33,6 +33,7 @@ final class NormalizeTests: XCTestCase {
 
     func testNormalizeAbove() {
         let resultValue = normalize(201.0, domain: 100.0 ... 200.0)
-        XCTAssertTrue(resultValue.isNaN)
+        XCTAssertEqual(resultValue, 1.01, accuracy: 0.0001)
+        //XCTAssertTrue(resultValue.isNaN)
     }
 }

--- a/Tests/SwiftVizTests/NormalizeTests.swift
+++ b/Tests/SwiftVizTests/NormalizeTests.swift
@@ -34,6 +34,6 @@ final class NormalizeTests: XCTestCase {
     func testNormalizeAbove() {
         let resultValue = normalize(201.0, domain: 100.0 ... 200.0)
         XCTAssertEqual(resultValue, 1.01, accuracy: 0.0001)
-        //XCTAssertTrue(resultValue.isNaN)
+        // XCTAssertTrue(resultValue.isNaN)
     }
 }

--- a/Tests/SwiftVizTests/TimeScaleTests.swift
+++ b/Tests/SwiftVizTests/TimeScaleTests.swift
@@ -1,6 +1,6 @@
 //
 //  TimeScaleTests.swift
-//  
+//
 //
 //  Created by Joseph Heck on 3/19/20.
 //
@@ -10,22 +10,21 @@ import XCTest
 
 func AssertEqualDates(_ firstDate: Date, _ secondDate: Date, accuracy: TimeInterval,
                       file: StaticString = #file, line: UInt = #line) {
-    //let timeDelta = firstDate.timeIntervalSince(secondDate)
-    XCTAssertTrue (firstDate.timeIntervalSince(secondDate) < accuracy, file: file, line: line)
+    // let timeDelta = firstDate.timeIntervalSince(secondDate)
+    XCTAssertTrue(firstDate.timeIntervalSince(secondDate) < accuracy, file: file, line: line)
 }
 
 // an extension to ClosedRange<Date>.contains to allow for slip in the date calculations
 // when interpretting through scale or invert
 extension ClosedRange where Bound == Date {
     public func contains(_ element: Bound, within: TimeInterval) -> Bool {
-        return element > self.lowerBound.addingTimeInterval(-within) &&
-            element < self.upperBound.addingTimeInterval(within)
+        element > lowerBound.addingTimeInterval(-within) &&
+            element < upperBound.addingTimeInterval(within)
     }
 }
 
 final class TimeScaleTests: XCTestCase {
     func testTimeScaleTicks() {
-
         let end = Date()
         let start = end - TimeInterval(300)
         let testRange = CGFloat(0) ... CGFloat(100.0)
@@ -40,9 +39,9 @@ final class TimeScaleTests: XCTestCase {
         for tick in defaultTicks {
             // every tick should be from within the scale's domain (input) range
             XCTAssertTrue(testRange.contains(tick.rangeLocation))
-            //print ("tick.value: \(tick.value) domain: \(scale.domain)")
+            // print ("tick.value: \(tick.value) domain: \(scale.domain)")
             // let result = scale.domain.contains(tick.value)
-            //print ("contained result: \(result)")
+            // print ("contained result: \(result)")
             XCTAssert(scale.domain.contains(tick.value, within: TimeInterval(0.1)))
         }
     }
@@ -120,6 +119,5 @@ final class TimeScaleTests: XCTestCase {
                          accuracy: TimeInterval(0.1))
         AssertEqualDates(clampedScale.invert(-50, range: testRange), start,
                          accuracy: TimeInterval(0.1))
-
     }
 }

--- a/Tests/SwiftVizTests/TimeScaleTests.swift
+++ b/Tests/SwiftVizTests/TimeScaleTests.swift
@@ -8,7 +8,7 @@
 @testable import SwiftViz
 import XCTest
 
-func AssertEqualDates(_ firstDate: Date, _ secondDate: Date, accuracy: TimeInterval,
+func assertEqualDates(_ firstDate: Date, _ secondDate: Date, accuracy: TimeInterval,
                       file: StaticString = #file, line: UInt = #line) {
     // let timeDelta = firstDate.timeIntervalSince(secondDate)
     XCTAssertTrue(firstDate.timeIntervalSince(secondDate) < accuracy, file: file, line: line)
@@ -103,21 +103,21 @@ final class TimeScaleTests: XCTestCase {
         let lowDate = end - TimeInterval(450)
 
         // no clamp effect
-        AssertEqualDates(scale.invert(50, range: testRange), middleDate,
+        assertEqualDates(scale.invert(50, range: testRange), middleDate,
                          accuracy: TimeInterval(0.1))
-        AssertEqualDates(clampedScale.invert(50, range: testRange), middleDate,
+        assertEqualDates(clampedScale.invert(50, range: testRange), middleDate,
                          accuracy: TimeInterval(0.1))
 
         // clamp constrained high
-        AssertEqualDates(scale.invert(150, range: testRange), highDate,
+        assertEqualDates(scale.invert(150, range: testRange), highDate,
                          accuracy: TimeInterval(0.1))
-        AssertEqualDates(clampedScale.invert(150, range: testRange), end,
+        assertEqualDates(clampedScale.invert(150, range: testRange), end,
                          accuracy: TimeInterval(0.1))
 
         // clamp constrained low
-        AssertEqualDates(scale.invert(-50, range: testRange), lowDate,
+        assertEqualDates(scale.invert(-50, range: testRange), lowDate,
                          accuracy: TimeInterval(0.1))
-        AssertEqualDates(clampedScale.invert(-50, range: testRange), start,
+        assertEqualDates(clampedScale.invert(-50, range: testRange), start,
                          accuracy: TimeInterval(0.1))
     }
 }

--- a/Tests/SwiftVizTests/TimeScaleTests.swift
+++ b/Tests/SwiftVizTests/TimeScaleTests.swift
@@ -1,0 +1,125 @@
+//
+//  TimeScaleTests.swift
+//  
+//
+//  Created by Joseph Heck on 3/19/20.
+//
+
+@testable import SwiftViz
+import XCTest
+
+func AssertEqualDates(_ firstDate: Date, _ secondDate: Date, accuracy: TimeInterval,
+                      file: StaticString = #file, line: UInt = #line) {
+    //let timeDelta = firstDate.timeIntervalSince(secondDate)
+    XCTAssertTrue (firstDate.timeIntervalSince(secondDate) < accuracy, file: file, line: line)
+}
+
+// an extension to ClosedRange<Date>.contains to allow for slip in the date calculations
+// when interpretting through scale or invert
+extension ClosedRange where Bound == Date {
+    public func contains(_ element: Bound, within: TimeInterval) -> Bool {
+        return element > self.lowerBound.addingTimeInterval(-within) &&
+            element < self.upperBound.addingTimeInterval(within)
+    }
+}
+
+final class TimeScaleTests: XCTestCase {
+    func testTimeScaleTicks() {
+
+        let end = Date()
+        let start = end - TimeInterval(300)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+
+        let scale = TimeScale(domain: start ... end)
+        XCTAssertFalse(scale.isClamped)
+        // XCTAssertTrue(scale.domain.contains(end))
+        // XCTAssertTrue(scale.domain.contains(start))
+
+        let defaultTicks = scale.ticks(range: testRange)
+        XCTAssertEqual(defaultTicks.count, 11)
+        for tick in defaultTicks {
+            // every tick should be from within the scale's domain (input) range
+            XCTAssertTrue(testRange.contains(tick.rangeLocation))
+            //print ("tick.value: \(tick.value) domain: \(scale.domain)")
+            // let result = scale.domain.contains(tick.value)
+            //print ("contained result: \(result)")
+            XCTAssert(scale.domain.contains(tick.value, within: TimeInterval(0.1)))
+        }
+    }
+
+    func testTimeScaleManualTicks() {
+        let end = Date()
+        let start = end - TimeInterval(300)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+
+        let scale = TimeScale(domain: start ... end)
+
+        let middleDate = end - TimeInterval(150)
+        let manualTicks = scale.ticks([start, middleDate, end], range: testRange)
+
+        XCTAssertEqual(manualTicks.count, 3)
+        for tick in manualTicks {
+            // every tick should be from within the scale's domain (input) range
+            XCTAssertTrue(testRange.contains(tick.rangeLocation))
+            XCTAssert(scale.domain.contains(tick.value))
+
+            XCTAssertTrue(testRange.contains(tick.rangeLocation))
+            XCTAssert(scale.domain.contains(tick.value, within: TimeInterval(0.1)))
+        }
+    }
+
+    func testTimeScaleClamp() {
+        let end = Date()
+        let start = end - TimeInterval(300)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+        let scale = TimeScale(domain: start ... end)
+        let clampedScale = TimeScale(domain: start ... end, isClamped: true)
+
+        let middleDate = end - TimeInterval(150)
+        let highDate = end + TimeInterval(150)
+        let lowDate = end - TimeInterval(450)
+
+        // no clamp effect
+        XCTAssertEqual(scale.scale(middleDate, range: testRange), 50)
+        XCTAssertEqual(clampedScale.scale(middleDate, range: testRange), 50)
+
+        // clamp constrained high
+        XCTAssertEqual(scale.scale(highDate, range: testRange), 150)
+        XCTAssertEqual(clampedScale.scale(highDate, range: testRange), 100)
+
+        // clamp constrained low
+        XCTAssertEqual(scale.scale(lowDate, range: testRange), -50)
+        XCTAssertEqual(clampedScale.scale(lowDate, range: testRange), 0)
+    }
+
+    func testTimeInvertClamp() {
+        let end = Date()
+        let start = end - TimeInterval(300)
+        let testRange = CGFloat(0) ... CGFloat(100.0)
+        let scale = TimeScale(domain: start ... end)
+        let clampedScale = TimeScale(domain: start ... end, isClamped: true)
+
+        let middleDate = end - TimeInterval(150)
+        let highDate = end + TimeInterval(150)
+        let lowDate = end - TimeInterval(450)
+
+        // no clamp effect
+        AssertEqualDates(scale.invert(50, range: testRange), middleDate,
+                         accuracy: TimeInterval(0.1))
+        AssertEqualDates(clampedScale.invert(50, range: testRange), middleDate,
+                         accuracy: TimeInterval(0.1))
+
+        // clamp constrained high
+        AssertEqualDates(scale.invert(150, range: testRange), highDate,
+                         accuracy: TimeInterval(0.1))
+        AssertEqualDates(clampedScale.invert(150, range: testRange), end,
+                         accuracy: TimeInterval(0.1))
+
+        // clamp constrained low
+        AssertEqualDates(scale.invert(-50, range: testRange), lowDate,
+                         accuracy: TimeInterval(0.1))
+        AssertEqualDates(clampedScale.invert(-50, range: testRange), start,
+                         accuracy: TimeInterval(0.1))
+
+    }
+}


### PR DESCRIPTION
and reverting previous domain constraints that were *always* applied - scales should now interpolate correctly through domain or range